### PR TITLE
change env var name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 singleplatform-0.1.0.gem
 singleplatform-0.1.1.gem
 singleplatform-0.2.2.gem
+.ruby-version
+.ruby-gemset

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ rvm:
   - 2.1
   - 2.0.0
 env:
-  - CLIENT_ID='abcdefg' CLIENT_SECRET='hijklmn'
+  - SINGLEPLATFORM_CLIENT_ID='abcdefg' SINGLEPLATFORM_CLIENT_SECRET='hijklmn'

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The gem uses a client model to query against the API. Create a client with your 
 require 'singleplatform'
 
 client = Singleplatform.new(
-  client_id:     ENV['CLIENT_ID']
-  client_secret: ENV['CLIENT_SECRET']
+  client_id:     ENV['SINGLEPLATFORM_CLIENT_ID']
+  client_secret: ENV['SINGLEPLATFORM_CLIENT_SECRET']
 )
 ```
 

--- a/lib/singleplatform/response.rb
+++ b/lib/singleplatform/response.rb
@@ -22,8 +22,8 @@ module Singleplatform
       return nil if next_page.nil? || next_page.empty?
       params = prepare_params(next_page)
       client = Singleplatform.new(
-        client_id:     ENV['CLIENT_ID'],
-        client_secret: ENV['CLIENT_SECRET']
+        client_id:     ENV['SINGLEPLATFORM_CLIENT_ID'],
+        client_secret: ENV['SINGLEPLATFORM_CLIENT_SECRET']
       )
       new_page = client.public_send(
                    origin.to_sym,
@@ -58,7 +58,7 @@ module Singleplatform
     # @return [Hash]
     def prepare_params(url)
       params = parse_params(url)
-      params['client'] = ENV['CLIENT_ID']
+      params['client'] = ENV['SINGLEPLATFORM_CLIENT_ID']
       params
     end
   end

--- a/singleplatform.gemspec
+++ b/singleplatform.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
+
+  spec.add_runtime_dependency "httparty", "~> 0.14.0"
 end

--- a/singleplatform.gemspec
+++ b/singleplatform.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
 
-  spec.add_runtime_dependency "httparty", "~> 0.14.0"
+  spec.add_runtime_dependency "httparty"
 end

--- a/spec/singleplatform/response_spec.rb
+++ b/spec/singleplatform/response_spec.rb
@@ -9,8 +9,8 @@ describe Singleplatform::Response do
       client_id:     'purplespacesuitfrogboots1',
       client_secret: 'yellowsubmarinesresonatewithmeandmybestbros'
     }
-    ENV['CLIENT_ID'] = @creds[:client_id]
-    ENV['CLIENT_SECRET'] = @creds[:client_secret]
+    ENV['SINGLEPLATFORM_CLIENT_ID'] = @creds[:client_id]
+    ENV['SINGLEPLATFORM_CLIENT_SECRET'] = @creds[:client_secret]
     @client = Singleplatform::Client.new(@creds)
     @updated_since = File.open(Dir.pwd + '/spec/support/fixtures/updated_since.json').read
   end


### PR DESCRIPTION
Hey there,

I'd love to use your gem, but it's within another project and the generic CLIENT_ID and CLIENT_SECRET don't work so well, so I forked and migrated them to SINGLEPLATFORM_CLIENT_ID and SINGLEPLATFORM_CLIENT_SECRET.

Additionally, when I first loaded it in, it didn't work because I didn't have httparty installed in my gems for the other project, and there's no runtime dependency on it for this gem.

Finally, I am using rvm and gemsets, so I added in a couple of lines to .gitignore just in case anyone else wants to use those while developing on this project, so the gemset and ruby version they're using don't get included in the project.

However, I'd be happy to strip out the second and third bits and re-submit if you want just the core change (env var name).

Thanks!
