### PR TITLE
allow for more complex dates in valid_date?

### DIFF
--- a/lib/singleplatform/client.rb
+++ b/lib/singleplatform/client.rb
@@ -72,9 +72,11 @@ module Singleplatform
     #
     # @return [Boolean]
     def valid_date?(date)
-      return false if date.index(/[^-0-9]/)
-      y, m, d = date.to_s.split('-')
-      Date.valid_date?(y.to_i, m.to_i, d.to_i)
+      begin
+        return (not date.to_date.nil?)
+      rescue StandardError => e
+        return false
+      end
     end
   end
 end

--- a/lib/singleplatform/client.rb
+++ b/lib/singleplatform/client.rb
@@ -73,7 +73,7 @@ module Singleplatform
     # @return [Boolean]
     def valid_date?(date)
       begin
-        return (not date.to_date.nil?)
+        return (not DateTime.parse(date).nil?)
       rescue StandardError => e
         return false
       end


### PR DESCRIPTION
Hey there, me again.

I am going to be using this to pull in data regularly in a live production environment.  I want to store the date that was the update date for the last restaurant fully parsed when doing an import via locations_updated_since, but the way that the current valid_date? was written, I couldn't use the more complex date string that was being passed back by the singleplatform API.

Now, it will work with literally any argument you pass in that returns a non-nil result for #to_date, and does not throw an error (the default behavior of a Ruby string that isn't a valid date format when you call #to_date is to throw an error).

This is inclusive of what you had before, but will accept a vastly larger set of potential inputs.
